### PR TITLE
TEST: fix test cases for version upgrades in the dependency crate - wat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ wasmer-engine-universal = "=2.3.0"
 wasmer-middlewares = "=2.3.0"
 wasmer-vm = "=2.3.0"
 wasmer-wasi = "=2.3.0"
-wat = "1.0.43"
 
 [dev-dependencies]
 base64url = "0.1.0"
 borsh = "0.10.2"
+wat = "1.0.73"
 
 [profile.release]
 overflow-checks = true

--- a/src/wasmer/non_determinism_filter.rs
+++ b/src/wasmer/non_determinism_filter.rs
@@ -309,14 +309,14 @@ mod tests {
     use wasmer_compiler_singlepass::Singlepass;
 
     #[test]
-    fn chech_i64_add() {
+    fn check_i64_add() {
         let wasm = wat::parse_str(
             r#"
             (module
                 (func (export "sum") (param i64 i64) (result i64)
-                    get_local 0
-                    get_local 1
-                    i64.add
+                    (local.get 0)
+                    (local.get 1)
+                    (i64.add)
                 ))
             "#,
         )
@@ -336,8 +336,8 @@ mod tests {
             r#"
             (module
                 (func $to_float (param i64) (result f64)
-                    get_local 0
-                    f64.convert_u/i64
+                    local.get 0
+                    f64.convert_i64_u
                 ))
             "#,
         )


### PR DESCRIPTION
There is a recent update in the one of the dev-dependency [wat](https://crates.io/crates/wat). It results in panics in test cases when parsing string into wasm test data.

The fix here is to update the string correctly so that test data can be prepared, and thus continues to proceed the test.